### PR TITLE
fix: misplaced settings toggle, fixes #1

### DIFF
--- a/src/Style/ThemeMaker.scss
+++ b/src/Style/ThemeMaker.scss
@@ -25,7 +25,7 @@
 	}
 
 	&:not(.active){
-		width: fit-content;
+		width: min-content;
 		min-width: unset;
 		.ez-tm-container{
 			display: none;


### PR DESCRIPTION
## Problem
#1 Occurred when settings sidebar was closed. Toggle button was misplaced.

## Description
First suggestion was to change `width` to `0` but it could fail in some situations where it was necessary to have content on the sidebar, so I believe `min-content` is better in this case because it will adjust to content width. 